### PR TITLE
Made the app compatible with older devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "com.kidseat.kidseat"
-        minSdkVersion 29
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Fixes issue #25 
Decreased the minSdkVersion from 29 to 21. Now, the app is compatible with Android versions 5.0 and above.

Useful link to the chart that shows the relationship between API levels and Android versions: https://source.android.com/setup/start/build-numbers